### PR TITLE
chore: lint ruby files on every push and schedule

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,15 @@
+on: push
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+      - name: Set up Ruby 2.6
+        uses: actions/setup-ruby@v1
+        with:
+          ruby-version: 2.6.x
+      - name: Lint Ruby Files
+        run: |
+          gem install rubocop
+          rubocop -l

--- a/.github/workflows/schedule.yml
+++ b/.github/workflows/schedule.yml
@@ -1,11 +1,11 @@
-name: 'Update Snyk Homebrew formula with latest release'
+name: "Update Snyk Homebrew formula with latest release"
 on:
   push:
     branches:
       - master
   schedule:
     # Run workflow once a day to grab latest Snyk release
-    - cron: '0 0 * * *'
+    - cron: "0 0 * * *"
 
 jobs:
   brew:
@@ -19,6 +19,10 @@ jobs:
       - name: Render latest template
         run: |
           ruby script/render.rb | tee Formula/snyk.rb
+      - name: Lint Ruby Files
+        run: |
+          gem install rubocop
+          rubocop -l
       - name: Commit to repository
         env:
           GITHUB_TOKEN: ${{ secrets.github_token }}


### PR DESCRIPTION
To avoid publishing syntax errors.

`rubocop` is a bit strict by default which might be useful but requires more work to get passing. `-l` just looks for syntax issues which is what we mainly need.