### PR TITLE
feat: use Snyk CDN for downloads instead of GH Releases

### DIFF
--- a/script/render.rb
+++ b/script/render.rb
@@ -16,27 +16,22 @@ require "erb"
 require "json"
 require "open-uri"
 
-PROJECT = "snyk/snyk"
 BIN = "snyk"
 
 # Return the URL, SHA and version information for a GitHub release
-def get_latest_release(project, bin)
-  api_url = "https://api.github.com/repos/#{project}/releases/latest"
-  data = URI.parse(api_url).read
+def get_latest_release(bin)
+  snyk_cli_version_url = "https://static.snyk.io/cli/latest/release.json"
+  data = URI.parse(snyk_cli_version_url).read
   obj = JSON.parse(data)
-  version = obj["name"]
-  sha_url = "https://github.com/#{project}/releases/download/#{version}/#{bin}.sha256"
-  sha = URI.parse(sha_url).read
-  url = "https://github.com/#{project}/releases/download/#{version}/#{bin}"
-  sha256 = sha.split(" ").first
+  version = obj["version"]
+  url = obj["assets"][bin]["url"]
+  sha256 = obj["assets"][bin]["sha256"].split.first
 
   return url, sha256, version
 end
 
-
-
-@url, @sha256, @version = get_latest_release(PROJECT, "#{BIN}-macos")
-@url_linux, @sha256_linux, _ = get_latest_release(PROJECT, "#{BIN}-linux")
+@url, @sha256, @version = get_latest_release("#{BIN}-macos")
+@url_linux, @sha256_linux, _ = get_latest_release("#{BIN}-linux")
 
 template = File.read(File.join(__dir__, "template.erb"))
 


### PR DESCRIPTION
This will lead to faster downloads, more stable generation and simplifies the code as well. Sample output for the Formula:

```yaml
class Snyk < Formula
  desc "Find & fix known vulnerabilities in open-source dependencies"
  homepage "https://github.com/snyk/snyk"
  version "1.661.0"

  if OS.mac?
    url "https://static.snyk.io/cli/v1.661.0/snyk-macos"
    sha256 "35355d49cc82bfcefd4b0079051b9f4b6f26cd5c371316ef1e3f99fed6bc32e5"
  elsif OS.linux?
    url "https://static.snyk.io/cli/v1.661.0/snyk-linux"
    sha256 "8a19224ec587ce007cd27f487192332b1d82a7147a4c77bb9e4b52f811379536"
  end

  def install
    bin.install (OS.linux? ? "snyk-linux" : "snyk-macos") => "snyk"
  end

  test do
    assert_match("Authentication failed.", shell_output("#{bin}/snyk auth homebrew-test", 2))
  end
end
```