### PR TITLE
fix: upgrade to ruby 3.2 in GH actions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -5,10 +5,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@master
-      - name: Set up Ruby 2.6
+      - name: Set up Ruby 3.2
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 2.6
+          ruby-version: 3.2
       - name: Lint Ruby Files
         run: |
           gem install rubocop

--- a/.github/workflows/schedule.yml
+++ b/.github/workflows/schedule.yml
@@ -13,10 +13,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@master
-      - name: Set up Ruby 2.6
+      - name: Set up Ruby 3.2
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 2.6
+          ruby-version: 3.2
       - name: Render latest template
         run: |
           ruby script/render.rb | tee Formula/snyk.rb


### PR DESCRIPTION
All GH actions started failing ~2 weeks ago when the latest rubocop version cut support for ruby 2.6.

I ran these ruby scripts and rubocop locally with 3.2 and seems to still work fine.