### PR TITLE
chore: add utm parameter

### DIFF
--- a/script/render.rb
+++ b/script/render.rb
@@ -27,7 +27,7 @@ def get_latest_release(bin)
   url = obj["assets"][bin]["url"]
   # Parse the URL and add the utm parameter
   uri = URI.parse(url)
-  new_query_ar = URI.decode_www_form(uri.query || '') << ["utm_source", "homebrew"]
+  new_query_ar = URI.decode_www_form(uri.query || '') << ["utm_source", "HOMEBREW"]
   uri.query = URI.encode_www_form(new_query_ar)
   url_with_utm = uri.to_s
 

--- a/script/render.rb
+++ b/script/render.rb
@@ -25,9 +25,15 @@ def get_latest_release(bin)
   obj = JSON.parse(data)
   version = obj["version"]
   url = obj["assets"][bin]["url"]
+  # Parse the URL and add the utm parameter
+  uri = URI.parse(url)
+  new_query_ar = URI.decode_www_form(uri.query || '') << ["utm_source", "homebrew"]
+  uri.query = URI.encode_www_form(new_query_ar)
+  url_with_utm = uri.to_s
+
   sha256 = obj["assets"][bin]["sha256"].split.first
 
-  return url, sha256, version
+  return url_with_utm, sha256, version
 end
 
 @url_macos, @sha256_macos, @version = get_latest_release("#{BIN}-macos")


### PR DESCRIPTION
How to test:

`cd script`
`ruby render.rb > test.rb`
`cat test.rb`

```ruby
class Snyk < Formula
  desc "Find & fix known vulnerabilities in open-source dependencies"
  homepage "https://github.com/snyk/snyk"
  version "1.1292.2"

  if OS.mac? && Hardware::CPU.intel?
    url "https://static.snyk.io/cli/v1.1292.2/snyk-macos?utm_source=homebrew"
    sha256 "efd066d52799fa964d6912d2cd94629c2ed2b014617107a1497efff2e09ef567"
    def install
      bin.install ("snyk-macos") => "snyk"
    end
  elsif OS.mac? && Hardware::CPU.arm?
    url "https://static.snyk.io/cli/v1.1292.2/snyk-macos-arm64?utm_source=homebrew"
    sha256 "54fcb68f6c13de740aef597bfae3f8d5faeac5db24c6c2f0040f7946292a6517"
    def install
      bin.install ("snyk-macos-arm64") => "snyk"
    end
  elsif OS.linux? && Hardware::CPU.intel?
    url "https://static.snyk.io/cli/v1.1292.2/snyk-linux?utm_source=homebrew"
    sha256 "4d4a81040a665428f3036f958a949621991a5501195d1345f17c260795009f1a"
    def install
      bin.install ("snyk-linux") => "snyk"
    end
  elsif OS.linux? && Hardware::CPU.arm?
    url "https://static.snyk.io/cli/v1.1292.2/snyk-linux-arm64?utm_source=homebrew"
    sha256 "5ddc071b56d31769c98fa06234b80e13e17a4505056f867c96b5abe8aeb3e865"
    def install
      bin.install ("snyk-linux-arm64") => "snyk"
    end
  end

  test do
    assert_match("Authentication failed.", shell_output("#{bin}/snyk auth homebrew-test", 2))
  end
end

```